### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -124,19 +124,19 @@ def extractDataFrom(data):
 outputFile = open (FINAL_OUTPUT_FILE, "w")
 outputFile.write(HEADER + "\n")
 for folder in INPUT_FOLDER:
-    print "---PROCESSING FOLDER %s---"% (folder,)
+    print "---PROCESSING FOLDER {0!s}---".format(folder)
     counter = 0
     for url in os.listdir(folder):
         data = open(folder + "/" + url).read()
         team1, team2, win_toss, bat_or_bowl, outcome, win_game, date, day_n_night, ground, rain, duckworth_lewis, match_id = extractDataFrom(data)
         url_new = folder + "/" + url
         type_of_match = folder.split("-")[-1].upper()
-        rowStr = '"%s","%s","%s","%s","%s","%s","%s","%s","%s","%s","%s","%s","%s","%s"\n'% (url_new,team1, team2, win_toss, bat_or_bowl, outcome, win_game, date, day_n_night, ground, rain, duckworth_lewis, match_id, type_of_match)
+        rowStr = '"{0!s}","{1!s}","{2!s}","{3!s}","{4!s}","{5!s}","{6!s}","{7!s}","{8!s}","{9!s}","{10!s}","{11!s}","{12!s}","{13!s}"\n'.format(url_new, team1, team2, win_toss, bat_or_bowl, outcome, win_game, date, day_n_night, ground, rain, duckworth_lewis, match_id, type_of_match)
         outputFile.write(rowStr)
         counter = counter + 1
         if counter%1000==0:
-            print "   + Processing file %d000th" % (counter/1000,)
+            print "   + Processing file {0:d}000th".format(counter/1000)
 outputFile.close()
 
 ##################################FINISHED#########################################
-print "DONE. Wrote output to %s" %(FINAL_OUTPUT_FILE,)
+print "DONE. Wrote output to {0!s}".format(FINAL_OUTPUT_FILE)

--- a/scripts/scraper.py
+++ b/scripts/scraper.py
@@ -42,7 +42,7 @@ for i in range(0, 6019):
         print str.split(new_host, "/")[4]
         html = urllib2.urlopen(odiurl).read()
         if html:
-            with open('espncricinfo-fc/%s' % str.split(new_host, "/")[4], "wb") as f:
+            with open('espncricinfo-fc/{0!s}'.format(str.split(new_host, "/")[4]), "wb") as f:
                 f.write(html)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:get-cricket-data?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:get-cricket-data?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
